### PR TITLE
feature: 플레이리스트 트랙 추가 기능 구현(기존 플레이리스트 저장 기능에서 수정)

### DIFF
--- a/src/docs/asciidoc/playlist-track.adoc
+++ b/src/docs/asciidoc/playlist-track.adoc
@@ -49,7 +49,7 @@ include::{snippets}/spotify/savePlaylistTrack/response-fields.adoc[]
 
 include::{snippets}/spotify/savePlaylistTrackFailUser/http-response.adoc[]
 
-=== 플레이리스트 저장 실패 (존재하지 않는 트랙)
+=== 플레이리스트 저장 실패 (존재하지 않는 플레이리스트)
 
 ==== Response
 

--- a/src/main/java/com/team/comma/spotify/playlist/controller/PlaylistTrackController.java
+++ b/src/main/java/com/team/comma/spotify/playlist/controller/PlaylistTrackController.java
@@ -32,7 +32,7 @@ public class PlaylistTrackController {
         );
     }
 
-    @PostMapping("/playlist-track")
+    @PostMapping("/playlists/tracks")
     public ResponseEntity<MessageResponse> createPlaylistTrack(
         @CookieValue(value = "accessToken") String accessToken,
         @RequestBody final PlaylistTrackSaveRequestDto requestDto

--- a/src/main/java/com/team/comma/spotify/playlist/controller/PlaylistTrackController.java
+++ b/src/main/java/com/team/comma/spotify/playlist/controller/PlaylistTrackController.java
@@ -32,7 +32,6 @@ public class PlaylistTrackController {
         );
     }
 
-
     @PostMapping("/playlist-track")
     public ResponseEntity<MessageResponse> createPlaylistTrack(
         @CookieValue(value = "accessToken") String accessToken,

--- a/src/main/java/com/team/comma/spotify/playlist/dto/PlaylistTrackSaveRequestDto.java
+++ b/src/main/java/com/team/comma/spotify/playlist/dto/PlaylistTrackSaveRequestDto.java
@@ -31,10 +31,6 @@ public class PlaylistTrackSaveRequestDto {
 
     private List<TrackRequest> trackList;
 
-    //
-//    private List<Long> trackIdList;
-    //
-
     @Setter
     @JsonIgnore
     private int listSequence;
@@ -48,12 +44,10 @@ public class PlaylistTrackSaveRequestDto {
         (
             @JsonProperty("playlistTitle") String playlistTitle,
             @JsonProperty("alarmStartTime") LocalTime alarmStartTime,
-//            @JsonProperty("trackIdList") List<Long> trackIdList
             @JsonProperty("trackList") List<TrackRequest> trackList
         ) {
         this.playlistTitle = playlistTitle;
         this.alarmStartTime = alarmStartTime;
-//        this.trackIdList = trackIdList;
         this.trackList = trackList;
     }
 

--- a/src/main/java/com/team/comma/spotify/playlist/dto/PlaylistTrackSaveRequestDto.java
+++ b/src/main/java/com/team/comma/spotify/playlist/dto/PlaylistTrackSaveRequestDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.team.comma.spotify.playlist.domain.Playlist;
 import com.team.comma.spotify.playlist.domain.PlaylistTrack;
 import com.team.comma.spotify.track.domain.Track;
+import com.team.comma.spotify.track.dto.TrackRequest;
 import com.team.comma.user.domain.User;
 import java.time.LocalTime;
 import java.util.List;
@@ -22,14 +23,20 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PlaylistTrackSaveRequestDto {
 
+    private List<Long> playlistIdList;
+
     private String playlistTitle;
 
     private LocalTime alarmStartTime;
 
-    private List<Long> trackIdList;
+    private List<TrackRequest> trackList;
 
-    @JsonIgnore
+    //
+//    private List<Long> trackIdList;
+    //
+
     @Setter
+    @JsonIgnore
     private int listSequence;
 
     @Setter
@@ -41,11 +48,13 @@ public class PlaylistTrackSaveRequestDto {
         (
             @JsonProperty("playlistTitle") String playlistTitle,
             @JsonProperty("alarmStartTime") LocalTime alarmStartTime,
-            @JsonProperty("trackIdList") List<Long> trackIdList
+//            @JsonProperty("trackIdList") List<Long> trackIdList
+            @JsonProperty("trackList") List<TrackRequest> trackList
         ) {
         this.playlistTitle = playlistTitle;
         this.alarmStartTime = alarmStartTime;
-        this.trackIdList = trackIdList;
+//        this.trackIdList = trackIdList;
+        this.trackList = trackList;
     }
 
     public Playlist toPlaylistEntity() {

--- a/src/main/java/com/team/comma/spotify/playlist/service/PlaylistService.java
+++ b/src/main/java/com/team/comma/spotify/playlist/service/PlaylistService.java
@@ -64,9 +64,8 @@ public class PlaylistService {
 
     @Transactional
     public MessageResponse updatePlaylist(PlaylistUpdateRequest playlistUpdateRequest) {
-
         Playlist playlist = playlistRepository.findById(playlistUpdateRequest.getId()).orElseThrow(
-            () -> new EntityNotFoundException("해당 플레이리스트가 없습니다."));
+            () -> new EntityNotFoundException("플레이리스트를 찾을 수 없습니다."));
         playlist.updatePlaylist(playlistUpdateRequest);
 
         return MessageResponse.of(REQUEST_SUCCESS);
@@ -75,7 +74,7 @@ public class PlaylistService {
     @Transactional
     public MessageResponse updatePlaylistAlarmFlag(long playlistId, boolean alarmFlag) {
         Playlist playlist = playlistRepository.findById(playlistId)
-                .orElseThrow(() -> new PlaylistException("플레이리스트가 존재하지 않습니다."));
+                .orElseThrow(() -> new PlaylistException("플레이리스트를 찾을 수 없습니다."));
 
         playlistRepository.updateAlarmFlag(playlistId, alarmFlag);
         return MessageResponse.of(PLAYLIST_ALARM_UPDATED);
@@ -85,7 +84,7 @@ public class PlaylistService {
     public MessageResponse updatePlaylistsDelFlag(List<Long> playlistIdList) {
         for(Long playlistId : playlistIdList){
             Playlist playlist = playlistRepository.findById(playlistId)
-                    .orElseThrow(() -> new PlaylistException("플레이리스트가 존재하지 않습니다."));
+                    .orElseThrow(() -> new PlaylistException("플레이리스트를 찾을 수 없습니다."));
         }
         for(Long playlistId : playlistIdList){
             playlistRepository.deletePlaylist(playlistId);

--- a/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
+++ b/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
@@ -70,7 +70,7 @@ public class PlaylistTrackService {
             playlistRepository.save(playlist);
 
             for (TrackRequest trackRequest : dto.getTrackList()) {
-                savePlaylistTrackAndTrackRequested(playlist,trackRequest);
+                savePlaylistTrackRequested(playlist,trackRequest);
             }
         } else {
             for (Long playlistId : dto.getPlaylistIdList()){
@@ -78,7 +78,7 @@ public class PlaylistTrackService {
                         .orElseThrow(() -> new PlaylistException("플레이리스트가 존재하지 않습니다."));
 
                 for (TrackRequest trackRequest : dto.getTrackList()) {
-                    savePlaylistTrackAndTrackRequested(playlist,trackRequest);
+                    savePlaylistTrackRequested(playlist,trackRequest);
                 }
             }
         }
@@ -89,11 +89,9 @@ public class PlaylistTrackService {
         );
     }
 
-    public void savePlaylistTrackAndTrackRequested(Playlist playlist, TrackRequest trackRequest){
-        Optional<Track> optionalTrack = trackRepository.findBySpotifyTrackId(trackRequest.getSpotifyTrackId());
-
-        Track track = (optionalTrack.isPresent()) ?
-                optionalTrack.get() : trackRepository.save(trackRequest.toTrackEntity());
+    public void savePlaylistTrackRequested(Playlist playlist, TrackRequest trackRequest){
+        Track track = trackRepository.findBySpotifyTrackId(trackRequest.getSpotifyTrackId())
+                .orElse(trackRepository.save(trackRequest.toTrackEntity()));
 
         Integer maxPlaySequence = playlistTrackRepository.
                 findMaxPlaySequenceByPlaylistId(playlist.getId())

--- a/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
+++ b/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
@@ -92,7 +92,7 @@ public class PlaylistTrackService {
         Track track = trackRepository.findBySpotifyTrackId(trackRequest.getSpotifyTrackId())
                 .orElse(trackRepository.save(trackRequest.toTrackEntity()));
 
-        Integer maxPlaySequence = playlistTrackRepository.
+        int maxPlaySequence = playlistTrackRepository.
                 findMaxPlaySequenceByPlaylistId(playlist.getId())
                 .orElse(0);
 

--- a/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
+++ b/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
@@ -6,14 +6,20 @@ import com.team.comma.common.dto.MessageResponse;
 import com.team.comma.spotify.playlist.domain.Playlist;
 import com.team.comma.spotify.playlist.domain.PlaylistTrack;
 import com.team.comma.spotify.playlist.dto.PlaylistTrackSaveRequestDto;
+import com.team.comma.spotify.playlist.exception.PlaylistException;
 import com.team.comma.spotify.playlist.repository.PlaylistRepository;
 import com.team.comma.spotify.playlist.repository.PlaylistTrackRepository;
 import com.team.comma.spotify.track.domain.Track;
+import com.team.comma.spotify.track.domain.TrackArtist;
+import com.team.comma.spotify.track.dto.TrackRequest;
+import com.team.comma.spotify.track.repository.TrackArtistRepository;
 import com.team.comma.spotify.track.repository.TrackRepository;
 import com.team.comma.user.domain.User;
 import com.team.comma.user.repository.UserRepository;
 import com.team.comma.util.jwt.support.JwtTokenProvider;
 import jakarta.persistence.EntityNotFoundException;
+
+import java.util.Optional;
 import java.util.Set;
 import javax.security.auth.login.AccountException;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +33,7 @@ public class PlaylistTrackService {
     private final PlaylistTrackRepository playlistTrackRepository;
     private final PlaylistRepository playlistRepository;
     private final TrackRepository trackRepository;
+    private final TrackArtistRepository trackArtistRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
 
@@ -47,8 +54,7 @@ public class PlaylistTrackService {
         );
     }
 
-    public MessageResponse savePlaylistTrackList(PlaylistTrackSaveRequestDto dto,
-        String accessToken)
+    public MessageResponse savePlaylistTrackList(PlaylistTrackSaveRequestDto dto, String accessToken)
         throws AccountException {
 
         String userEmail = jwtTokenProvider.getUserPk(accessToken);
@@ -59,23 +65,22 @@ public class PlaylistTrackService {
             throw new AccountException("사용자를 찾을 수 없습니다.");
         }
 
-        Playlist playlist = dto.toPlaylistEntity();
-        playlistRepository.save(playlist);
+        if (dto.getPlaylistIdList() == null){
+            Playlist playlist = dto.toPlaylistEntity();
+            playlistRepository.save(playlist);
 
-        for (Long trackId : dto.getTrackIdList()) {
-            Track eachTrack = trackRepository.findById(trackId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 트랙이 존재하지 않습니다."));
+            for (TrackRequest trackRequest : dto.getTrackList()) {
+                savePlaylistTrackAndTrackRequested(playlist,trackRequest);
+            }
+        } else {
+            for (Long playlistId : dto.getPlaylistIdList()){
+                Playlist playlist = playlistRepository.findById(playlistId)
+                        .orElseThrow(() -> new PlaylistException("플레이리스트가 존재하지 않습니다."));
 
-            Integer maxPlaySequence = playlistTrackRepository.
-                findMaxPlaySequenceByPlaylistId(playlist.getId())
-                .orElse(0);
-
-            PlaylistTrack eachPlaylistTrack = PlaylistTrack.builder()
-                .playlist(playlist)
-                .track(eachTrack)
-                .playSequence(maxPlaySequence + 1)
-                .build();
-            playlistTrackRepository.save(eachPlaylistTrack);
+                for (TrackRequest trackRequest : dto.getTrackList()) {
+                    savePlaylistTrackAndTrackRequested(playlist,trackRequest);
+                }
+            }
         }
 
         return MessageResponse.of(
@@ -83,5 +88,23 @@ public class PlaylistTrackService {
             REQUEST_SUCCESS.getMessage()
         );
     }
-}
 
+    public void savePlaylistTrackAndTrackRequested(Playlist playlist, TrackRequest trackRequest){
+        Optional<Track> optionalTrack = trackRepository.findBySpotifyTrackId(trackRequest.getSpotifyTrackId());
+
+        Track track = (optionalTrack.isPresent()) ?
+                optionalTrack.get() : trackRepository.save(trackRequest.toTrackEntity());
+
+        Integer maxPlaySequence = playlistTrackRepository.
+                findMaxPlaySequenceByPlaylistId(playlist.getId())
+                .orElse(0);
+
+        PlaylistTrack eachPlaylistTrack = PlaylistTrack.builder()
+                .playlist(playlist)
+                .track(track)
+                .playSequence(maxPlaySequence + 1)
+                .build();
+        playlistTrackRepository.save(eachPlaylistTrack);
+    }
+
+}

--- a/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
+++ b/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
@@ -104,5 +104,5 @@ public class PlaylistTrackService {
                 .build();
         playlistTrackRepository.save(eachPlaylistTrack);
     }
-
+// 커밋 테스트
 }

--- a/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
+++ b/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
@@ -33,7 +33,6 @@ public class PlaylistTrackService {
     private final PlaylistTrackRepository playlistTrackRepository;
     private final PlaylistRepository playlistRepository;
     private final TrackRepository trackRepository;
-    private final TrackArtistRepository trackArtistRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
 
@@ -65,20 +64,20 @@ public class PlaylistTrackService {
             throw new AccountException("사용자를 찾을 수 없습니다.");
         }
 
-        if (dto.getPlaylistIdList() == null){
+        if (dto.getPlaylistIdList().isEmpty()){
             Playlist playlist = dto.toPlaylistEntity();
             playlistRepository.save(playlist);
 
             for (TrackRequest trackRequest : dto.getTrackList()) {
-                savePlaylistTrackRequested(playlist,trackRequest);
+                addTrackToPlaylist(playlist,trackRequest);
             }
         } else {
             for (Long playlistId : dto.getPlaylistIdList()){
                 Playlist playlist = playlistRepository.findById(playlistId)
-                        .orElseThrow(() -> new PlaylistException("플레이리스트가 존재하지 않습니다."));
+                        .orElseThrow(() -> new PlaylistException("플레이리스트를 찾을 수 없습니다."));
 
                 for (TrackRequest trackRequest : dto.getTrackList()) {
-                    savePlaylistTrackRequested(playlist,trackRequest);
+                    addTrackToPlaylist(playlist,trackRequest);
                 }
             }
         }
@@ -89,7 +88,7 @@ public class PlaylistTrackService {
         );
     }
 
-    public void savePlaylistTrackRequested(Playlist playlist, TrackRequest trackRequest){
+    public void addTrackToPlaylist(Playlist playlist, TrackRequest trackRequest){
         Track track = trackRepository.findBySpotifyTrackId(trackRequest.getSpotifyTrackId())
                 .orElse(trackRepository.save(trackRequest.toTrackEntity()));
 

--- a/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
+++ b/src/main/java/com/team/comma/spotify/playlist/service/PlaylistTrackService.java
@@ -104,5 +104,5 @@ public class PlaylistTrackService {
                 .build();
         playlistTrackRepository.save(eachPlaylistTrack);
     }
-// 커밋 테스트
+
 }

--- a/src/main/java/com/team/comma/spotify/track/dto/TrackRequest.java
+++ b/src/main/java/com/team/comma/spotify/track/dto/TrackRequest.java
@@ -1,0 +1,44 @@
+package com.team.comma.spotify.track.dto;
+
+import com.team.comma.spotify.playlist.domain.Playlist;
+import com.team.comma.spotify.track.domain.Track;
+import com.team.comma.spotify.track.domain.TrackArtist;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class TrackRequest {
+
+    private String trackTitle;
+
+    private String albumImageUrl;
+
+    private String spotifyTrackId;
+
+    private String spotifyTrackHref;
+
+    private List<String> trackArtistList;
+
+    public Track toTrackEntity() {
+        return Track.builder()
+                .trackTitle(trackTitle)
+                .albumImageUrl(albumImageUrl)
+                .spotifyTrackId(spotifyTrackId)
+                .spotifyTrackHref(spotifyTrackHref)
+                .trackArtistList(buildTrackArtistList(trackArtistList))
+                .build();
+    }
+    public List<TrackArtist> buildTrackArtistList(List<String> artistList) {
+        ArrayList<TrackArtist> trackArtistList = new ArrayList<>();
+        for (String artist : artistList){
+            trackArtistList.add(TrackArtist.builder().artistName(artist).build());
+        }
+        return trackArtistList;
+    }
+}

--- a/src/main/java/com/team/comma/spotify/track/repository/TrackArtistRepository.java
+++ b/src/main/java/com/team/comma/spotify/track/repository/TrackArtistRepository.java
@@ -1,0 +1,7 @@
+package com.team.comma.spotify.track.repository;
+
+import com.team.comma.spotify.track.domain.TrackArtist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrackArtistRepository extends JpaRepository<TrackArtist, Long> {
+}

--- a/src/main/java/com/team/comma/spotify/track/repository/TrackRepository.java
+++ b/src/main/java/com/team/comma/spotify/track/repository/TrackRepository.java
@@ -9,5 +9,5 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
 
     List<Track> findAllById(Long id);
 
-
+    Optional<Track> findBySpotifyTrackId(String spotifyTrackId);
 }

--- a/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistControllerTest.java
@@ -151,6 +151,7 @@ class PlaylistControllerTest {
     void 플레이리스트_알람설정변경_성공() throws Exception {
         // given
         final String url = "/playlist/alert";
+
         doReturn(MessageResponse.of(PLAYLIST_ALARM_UPDATED)
         ).when(playlistService).updatePlaylistAlarmFlag(123L, false);
 
@@ -184,6 +185,7 @@ class PlaylistControllerTest {
     void 플레이리스트_알람설정변경_실패_플레이리스트_찾을수없음() throws Exception {
         // given
         final String url = "/playlist/alert";
+
         doThrow(new PlaylistException("플레이리스트를 찾을 수 없습니다."))
                 .when(playlistService).updatePlaylistAlarmFlag(123L, false);
 
@@ -218,6 +220,7 @@ class PlaylistControllerTest {
         // given
         final String url = "/playlist";
         final List<Long> playlistIdList = Arrays.asList(123L, 124L);
+
         doReturn(MessageResponse.of(PLAYLIST_DELETED)
         ).when(playlistService).updatePlaylistsDelFlag(playlistIdList);
 
@@ -250,6 +253,7 @@ class PlaylistControllerTest {
         // given
         final String url = "/playlist";
         final List<Long> playlistIdList = Arrays.asList(123L, 124L);
+
         doThrow(new PlaylistException("플레이리스트가 존재하지 않습니다. 다시 시도해 주세요."))
                 .when(playlistService).updatePlaylistsDelFlag(playlistIdList);
 

--- a/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistControllerTest.java
@@ -278,7 +278,7 @@ class PlaylistControllerTest {
         final String url = "/playlist";
         final List<Long> playlistIdList = Arrays.asList(123L, 124L);
 
-        doThrow(new PlaylistException("플레이리스트가 존재하지 않습니다. 다시 시도해 주세요."))
+        doThrow(new PlaylistException("플레이리스트를 찾을 수 없습니다."))
                 .when(playlistService).updatePlaylistsDelFlag(playlistIdList);
 
         // when

--- a/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistControllerTest.java
@@ -42,6 +42,7 @@ import com.team.comma.util.gson.GsonUtil;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.Cookie;
 
+import java.nio.charset.StandardCharsets;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
@@ -116,7 +117,6 @@ class PlaylistControllerTest {
             RestDocumentationRequestBuilders.get(url)
                 .cookie(new Cookie("accessToken", "accessToken"))
                 .contentType(MediaType.APPLICATION_JSON));
-        final List<PlaylistResponse> result = playlistService.getPlaylists("accessToken");
 
         // then
         resultActions.andExpect(status().isOk()).andDo(
@@ -144,6 +144,9 @@ class PlaylistControllerTest {
                 )
             )
         );
+
+        final List<PlaylistResponse> result = playlistService.getPlaylists("accessToken");
+
         assertThat(result).hasSize(1);
     }
 
@@ -179,6 +182,13 @@ class PlaylistControllerTest {
                 )
             )
         );
+
+        final MessageResponse result = gson.fromJson(
+                resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+                MessageResponse.class);
+
+        assertThat(result.getCode()).isEqualTo(PLAYLIST_ALARM_UPDATED.getCode());
+        assertThat(result.getMessage()).isEqualTo(PLAYLIST_ALARM_UPDATED.getMessage());
     }
 
     @Test
@@ -213,6 +223,13 @@ class PlaylistControllerTest {
                         )
                 )
         );
+
+        final MessageResponse result = gson.fromJson(
+                resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+                MessageResponse.class);
+
+        assertThat(result.getCode()).isEqualTo(PLAYLIST_NOT_FOUND.getCode());
+        assertThat(result.getMessage()).isEqualTo(PLAYLIST_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -246,6 +263,13 @@ class PlaylistControllerTest {
                         )
                 )
         );
+
+        final MessageResponse result = gson.fromJson(
+                resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+                MessageResponse.class);
+
+        assertThat(result.getCode()).isEqualTo(PLAYLIST_DELETED.getCode());
+        assertThat(result.getMessage()).isEqualTo(PLAYLIST_DELETED.getMessage());
     }
 
     @Test
@@ -279,6 +303,13 @@ class PlaylistControllerTest {
                         )
                 )
         );
+
+        final MessageResponse result = gson.fromJson(
+                resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+                MessageResponse.class);
+
+        assertThat(result.getCode()).isEqualTo(PLAYLIST_NOT_FOUND.getCode());
+        assertThat(result.getMessage()).isEqualTo(PLAYLIST_NOT_FOUND.getMessage());
     }
 
     @Test

--- a/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistTrackControllerTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistTrackControllerTest.java
@@ -1,6 +1,7 @@
 package com.team.comma.spotify.playlist.controller;
 
-import static com.team.comma.common.constant.ResponseCodeEnum.REQUEST_SUCCESS;
+import static com.team.comma.common.constant.ResponseCodeEnum.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -27,12 +28,15 @@ import com.team.comma.common.dto.MessageResponse;
 import com.team.comma.spotify.playlist.dto.PlaylistTrackRequest;
 import com.team.comma.spotify.playlist.dto.PlaylistTrackSaveRequestDto;
 import com.team.comma.spotify.playlist.dto.PlaylistUpdateRequest;
+import com.team.comma.spotify.playlist.exception.PlaylistException;
 import com.team.comma.spotify.playlist.service.PlaylistTrackService;
 import com.team.comma.spotify.track.dto.TrackRequest;
 import com.team.comma.user.domain.User;
 import com.team.comma.util.gson.GsonUtil;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.Cookie;
+
+import java.nio.charset.StandardCharsets;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Set;
@@ -218,7 +222,7 @@ class PlaylistTrackControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(
-            post("/playlist-track")
+            post("/playlists/tracks")
                 .contentType(APPLICATION_JSON)
                 .content(body)
                 .cookie(accessToken)
@@ -249,6 +253,13 @@ class PlaylistTrackControllerTest {
                     )
                 )
             );
+
+        final MessageResponse result = gson.fromJson(
+                resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+                MessageResponse.class);
+
+        assertThat(result.getCode()).isEqualTo(REQUEST_SUCCESS.getCode());
+        assertThat(result.getMessage()).isEqualTo(REQUEST_SUCCESS.getMessage());
     }
 
 
@@ -257,12 +268,6 @@ class PlaylistTrackControllerTest {
         //given
         Cookie accessToken = new Cookie("accessToken", "testToken");
         User user = User.builder().email(userEmail).build();
-
-        MessageResponse messageResponse = MessageResponse.of
-            (
-                REQUEST_SUCCESS.getCode(),
-                REQUEST_SUCCESS.getMessage()
-            );
 
         String body = objectMapper.writeValueAsString(PlaylistUpdateRequest.builder()
             .playlistTitle("test playlist")
@@ -275,7 +280,7 @@ class PlaylistTrackControllerTest {
 
         //when
         ResultActions resultActions = mockMvc.perform(
-            post("/playlist-track")
+            post("/playlists/tracks")
                 .contentType(APPLICATION_JSON)
                 .content(body)
                 .cookie(accessToken)
@@ -295,10 +300,17 @@ class PlaylistTrackControllerTest {
                     )
                 )
             );
+
+        final MessageResponse result = gson.fromJson(
+                resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+                MessageResponse.class);
+
+        assertThat(result.getCode()).isEqualTo(SIMPLE_REQUEST_FAILURE.getCode());
+        assertThat(result.getMessage()).isEqualTo("사용자를 찾을 수 없습니다.");
     }
 
     @Test
-    void 플레이리스트트랙_저장_실패_존재하지않는_트랙() throws Exception {
+    void 플레이리스트트랙_저장_실패_존재하지않는_플레이리스트() throws Exception {
         //given
         Cookie accessToken = new Cookie("accessToken", "testToken");
         User user = User.builder().email(userEmail).build();
@@ -309,18 +321,27 @@ class PlaylistTrackControllerTest {
                 REQUEST_SUCCESS.getMessage()
             );
 
-        String body = objectMapper.writeValueAsString(PlaylistUpdateRequest.builder()
-            .playlistTitle("test playlist")
-            .alarmStartTime(LocalTime.of(10, 10))
-            .build());
+        TrackRequest trackRequest = TrackRequest.builder()
+                .trackTitle("test track")
+                .albumImageUrl("url/track")
+                .spotifyTrackId("input ISRC")
+                .spotifyTrackHref("input href")
+                .trackArtistList(List.of("artist","artist")).build();
 
-        doThrow(new EntityNotFoundException("해당 트랙이 존재하지 않습니다."))
+        String body = objectMapper.writeValueAsString(PlaylistTrackSaveRequestDto.builder()
+                .playlistIdList(List.of(1L,2L,3L))
+                .playlistTitle("test playlist")
+                .alarmStartTime(LocalTime.of(10, 10))
+                .trackList(List.of(trackRequest))
+                .build());
+
+        doThrow(new PlaylistException("플레이리스트를 찾을 수 없습니다."))
             .when(playlistTrackService)
             .savePlaylistTrackList(any(PlaylistTrackSaveRequestDto.class), anyString());
 
         //when
         ResultActions resultActions = mockMvc.perform(
-            post("/playlist-track")
+            post("/playlists/tracks")
                 .contentType(APPLICATION_JSON)
                 .content(body)
                 .cookie(accessToken)
@@ -340,6 +361,13 @@ class PlaylistTrackControllerTest {
                     )
                 )
             );
+
+        final MessageResponse result = gson.fromJson(
+                resultActions.andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8),
+                MessageResponse.class);
+
+        assertThat(result.getCode()).isEqualTo(PLAYLIST_NOT_FOUND.getCode());
+        assertThat(result.getMessage()).isEqualTo("플레이리스트를 찾을 수 없습니다.");
     }
 
 

--- a/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistTrackControllerTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/controller/PlaylistTrackControllerTest.java
@@ -28,6 +28,7 @@ import com.team.comma.spotify.playlist.dto.PlaylistTrackRequest;
 import com.team.comma.spotify.playlist.dto.PlaylistTrackSaveRequestDto;
 import com.team.comma.spotify.playlist.dto.PlaylistUpdateRequest;
 import com.team.comma.spotify.playlist.service.PlaylistTrackService;
+import com.team.comma.spotify.track.dto.TrackRequest;
 import com.team.comma.user.domain.User;
 import com.team.comma.util.gson.GsonUtil;
 import jakarta.persistence.EntityNotFoundException;
@@ -197,10 +198,18 @@ class PlaylistTrackControllerTest {
                 REQUEST_SUCCESS.getMessage()
             );
 
+        TrackRequest trackRequest = TrackRequest.builder()
+                .trackTitle("test track")
+                .albumImageUrl("url/track")
+                .spotifyTrackId("input ISRC")
+                .spotifyTrackHref("input href")
+                .trackArtistList(List.of("artist","artist")).build();
+
         String body = objectMapper.writeValueAsString(PlaylistTrackSaveRequestDto.builder()
+            .playlistIdList(List.of(1L,2L,3L))
             .playlistTitle("test playlist")
             .alarmStartTime(LocalTime.of(10, 10))
-            .trackIdList(List.of(1L, 2L, 3L))
+            .trackList(List.of(trackRequest))
             .build());
 
         doReturn(messageResponse)
@@ -223,9 +232,15 @@ class PlaylistTrackControllerTest {
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     requestFields(
+                        fieldWithPath("playlistIdList").description("플레이리스트 ID 리스트, 신규 생성의 경우 입력받지 않음"),
                         fieldWithPath("playlistTitle").description("플레이리스트 제목"),
                         fieldWithPath("alarmStartTime").description("알람 시작 시간"),
-                        fieldWithPath("trackIdList").description("저장할 트랙 id 리스트")
+                        fieldWithPath("trackList").description("저장할 트랙 정보 리스트"),
+                        fieldWithPath("trackList.[].trackTitle").description("트랙 제목"),
+                        fieldWithPath("trackList.[].albumImageUrl").description("트랙 앨범 이미지 경로"),
+                        fieldWithPath("trackList.[].spotifyTrackId").description("트랙 ISRC 값"),
+                        fieldWithPath("trackList.[].spotifyTrackHref").description("트랙 href"),
+                        fieldWithPath("trackList.[].trackArtistList").description("트랙 아티스트 이름 리스트")
                     ),
                     responseFields(
                         fieldWithPath("code").description("응답 코드"),

--- a/src/test/java/com/team/comma/spotify/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/service/PlaylistServiceTest.java
@@ -89,7 +89,7 @@ class PlaylistServiceTest {
         final Throwable thrown = catchThrowable(() -> playlistService.updatePlaylistAlarmFlag(123L, false));
 
         // then
-        assertThat(thrown.getMessage()).isEqualTo("플레이리스트가 존재하지 않습니다.");
+        assertThat(thrown.getMessage()).isEqualTo("플레이리스트를 찾을 수 없습니다.");
     }
 
     @Test
@@ -119,7 +119,7 @@ class PlaylistServiceTest {
         final Throwable thrown = catchThrowable(() -> playlistService.updatePlaylistsDelFlag(playlistIdList));
 
         // then
-        assertThat(thrown.getMessage()).isEqualTo("플레이리스트가 존재하지 않습니다.");
+        assertThat(thrown.getMessage()).isEqualTo("플레이리스트를 찾을 수 없습니다.");
     }
 
     @Test

--- a/src/test/java/com/team/comma/spotify/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/service/PlaylistServiceTest.java
@@ -74,7 +74,6 @@ class PlaylistServiceTest {
         );
         doReturn(userPlaylist).when(playlistRepository).findAllByUserAndDelFlag(user, false);
 
-
         // when
         final List<PlaylistResponse> result = playlistService.getPlaylists(token);
 

--- a/src/test/java/com/team/comma/spotify/playlist/service/PlaylistTrackServiceTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/service/PlaylistTrackServiceTest.java
@@ -136,6 +136,7 @@ class PlaylistTrackServiceTest {
                 .build();
 
         PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+                .playlistIdList(List.of())
                 .playlistTitle("플리 타이틀")
                 .alarmStartTime(LocalTime.now())
                 .listSequence(1)
@@ -173,6 +174,7 @@ class PlaylistTrackServiceTest {
         Track track = trackRequest.toTrackEntity();
 
         PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+                .playlistIdList(List.of())
                 .playlistTitle("플리 타이틀")
                 .alarmStartTime(LocalTime.now())
                 .listSequence(1)
@@ -308,7 +310,7 @@ class PlaylistTrackServiceTest {
         final Throwable thrown = catchThrowable(() -> playlistTrackService.savePlaylistTrackList(requestDto, accessToken));
 
         // then
-        assertThat(thrown.getMessage()).isEqualTo("플레이리스트가 존재하지 않습니다.");
+        assertThat(thrown.getMessage()).isEqualTo("플레이리스트를 찾을 수 없습니다.");
     }
 
 }

--- a/src/test/java/com/team/comma/spotify/playlist/service/PlaylistTrackServiceTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/service/PlaylistTrackServiceTest.java
@@ -101,78 +101,6 @@ class PlaylistTrackServiceTest {
 
     }
 
-//    @Test
-//    void 플레이리스트와_트랙들을_PlaylistTrackSaveRequestDto로_저장한다() throws AccountException {
-//        //given
-//        final String accessToken = "accessToken";
-//        final String userEmail = "test@email.com";
-//
-//        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
-//            .playlistTitle("플리 타이틀")
-//            .alarmStartTime(LocalTime.now())
-//            .listSequence(1)
-//            .trackList(List.of(TrackRequest.builder().build()))
-//            .build();
-//
-//        Playlist playlist = requestDto.toPlaylistEntity();
-//
-//        doReturn(userEmail)
-//            .when(jwtTokenProvider).getUserPk(accessToken);
-//
-//        doReturn(Optional.of(User.builder().email(userEmail).build()))
-//            .when(userRepository).findByEmail(userEmail);
-//
-//        doReturn(Optional.of(1))
-//            .when(playlistTrackRepository).findMaxPlaySequenceByPlaylistId(playlist.getId());
-//
-//        doReturn(playlist)
-//            .when(playlistRepository).save(any(Playlist.class));
-//
-//        doReturn(Optional.of(Track.builder().build()))
-//            .when(trackRepository).findById(anyLong());
-//
-//        doReturn(PlaylistTrack.builder().build())
-//            .when(playlistTrackRepository).save(any(PlaylistTrack.class));
-//
-//        //when
-//        MessageResponse messageResponse = playlistTrackService.savePlaylistTrackList(requestDto,
-//            accessToken);
-//
-//        //then
-//        assertThat(messageResponse.getCode()).isEqualTo(REQUEST_SUCCESS.getCode());
-//        assertThat(messageResponse.getMessage()).isEqualTo(REQUEST_SUCCESS.getMessage());
-//
-//    }
-
-//    @Test
-//    void 트랙이_존재하지않으면_EntityNotFoundException() throws AccountException {
-//        //given
-//        final String accessToken = "accessToken";
-//        final String userEmail = "test@email.com";
-//
-//        User user = User.builder().email(userEmail).build();
-//
-//        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
-//            .playlistTitle("플리 타이틀")
-//            .alarmStartTime(LocalTime.now())
-//            .listSequence(1)
-//            .trackIdList(List.of(1L, 2L, 3L))
-//            .build();
-//
-//        Playlist playlist = requestDto.toPlaylistEntity();
-//
-//        doReturn(userEmail)
-//            .when(jwtTokenProvider).getUserPk(accessToken);
-//        doReturn(Optional.of(user))
-//            .when(userRepository).findByEmail(userEmail);
-//
-//        //when
-//        //then
-//        assertThatThrownBy(
-//            () -> playlistTrackService.savePlaylistTrackList(requestDto, accessToken))
-//            .isInstanceOf(EntityNotFoundException.class);
-//    }
-
     @Test
     void 사용자가_존재하지않으면_UsernameNotFoundException() {
         //given
@@ -193,7 +121,7 @@ class PlaylistTrackServiceTest {
     }
 
     @Test
-    void 트랙_저장_성공_플레이리스트ID리스트가_비어있고_track이_존재하지않으면_트랙_신규_저장_및_플레이리스트_신규_저장() throws AccountException {
+    void 트랙_저장_성공_playlistIdList_비어있고_track_존재하지않으면_트랙_신규_저장_후_플레이리스트_신규_저장() throws AccountException {
         //given
         final String accessToken = "accessToken";
         final String userEmail = "test@email.com";
@@ -229,7 +157,7 @@ class PlaylistTrackServiceTest {
     }
 
     @Test
-    void 트랙_저장_성공_플레이리스트ID리스트가_비어있고_track이_존재하면_플레이리스트_신규_저장() throws AccountException {
+    void 트랙_저장_성공_playlistIdList_비어있고_track_존재하면_플레이리스트_신규_저장() throws AccountException {
         //given
         final String accessToken = "accessToken";
         final String userEmail = "test@email.com";
@@ -267,7 +195,7 @@ class PlaylistTrackServiceTest {
     }
 
     @Test
-    void 트랙_저장_성공_플레이리스트ID리스트가_비어있지않고_track이_존재하지않으면_트랙_신규_저장_및_플레이리스트_트랙_추가() throws AccountException {
+    void 트랙_저장_성공_playlistIdList_비어있지않고_track_존재하지않으면_트랙_신규_저장_후_플레이리스트_트랙_추가() throws AccountException {
         //given
         final String accessToken = "accessToken";
         final String userEmail = "test@email.com";
@@ -307,7 +235,7 @@ class PlaylistTrackServiceTest {
     }
 
     @Test
-    void 트랙_저장_성공_플레이리스트ID리스트가_비어있지않고_track이_존재하면_플레이리스트_트랙_추가() throws AccountException {
+    void 트랙_저장_성공_playlistIdList_비어있지않고_track_존재하면_플레이리스트_트랙_추가() throws AccountException {
         //given
         final String accessToken = "accessToken";
         final String userEmail = "test@email.com";
@@ -350,7 +278,7 @@ class PlaylistTrackServiceTest {
     }
 
     @Test
-    void 트랙_저장_실패_playlistIdList_중_존재하지않는_플레이리스트_포함됨() throws PlaylistException {
+    void 트랙_저장_실패_playlistIdList_존재하지않는_플레이리스트_포함() throws PlaylistException {
         final String accessToken = "accessToken";
         final String userEmail = "test@email.com";
         final User user = User.builder().email(userEmail).build();

--- a/src/test/java/com/team/comma/spotify/playlist/service/PlaylistTrackServiceTest.java
+++ b/src/test/java/com/team/comma/spotify/playlist/service/PlaylistTrackServiceTest.java
@@ -1,8 +1,7 @@
 package com.team.comma.spotify.playlist.service;
 
 import static com.team.comma.common.constant.ResponseCodeEnum.REQUEST_SUCCESS;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -13,9 +12,12 @@ import com.team.comma.common.dto.MessageResponse;
 import com.team.comma.spotify.playlist.domain.Playlist;
 import com.team.comma.spotify.playlist.domain.PlaylistTrack;
 import com.team.comma.spotify.playlist.dto.PlaylistTrackSaveRequestDto;
+import com.team.comma.spotify.playlist.exception.PlaylistException;
 import com.team.comma.spotify.playlist.repository.PlaylistRepository;
 import com.team.comma.spotify.playlist.repository.PlaylistTrackRepository;
 import com.team.comma.spotify.track.domain.Track;
+import com.team.comma.spotify.track.domain.TrackArtist;
+import com.team.comma.spotify.track.dto.TrackRequest;
 import com.team.comma.spotify.track.repository.TrackRepository;
 import com.team.comma.user.domain.User;
 import com.team.comma.user.repository.UserRepository;
@@ -58,6 +60,9 @@ class PlaylistTrackServiceTest {
     @Mock
     UserRepository userRepository;
 
+
+    private String spotifyTrackId = "input ISRC of track";
+
     @Test
     void 플리에_담긴_트랙들을_삭제한다() {
         //given
@@ -96,77 +101,77 @@ class PlaylistTrackServiceTest {
 
     }
 
-    @Test
-    void 플레이리스트와_트랙들을_PlaylistTrackSaveRequestDto로_저장한다() throws AccountException {
-        //given
-        final String accessToken = "accessToken";
-        final String userEmail = "test@email.com";
+//    @Test
+//    void 플레이리스트와_트랙들을_PlaylistTrackSaveRequestDto로_저장한다() throws AccountException {
+//        //given
+//        final String accessToken = "accessToken";
+//        final String userEmail = "test@email.com";
+//
+//        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+//            .playlistTitle("플리 타이틀")
+//            .alarmStartTime(LocalTime.now())
+//            .listSequence(1)
+//            .trackList(List.of(TrackRequest.builder().build()))
+//            .build();
+//
+//        Playlist playlist = requestDto.toPlaylistEntity();
+//
+//        doReturn(userEmail)
+//            .when(jwtTokenProvider).getUserPk(accessToken);
+//
+//        doReturn(Optional.of(User.builder().email(userEmail).build()))
+//            .when(userRepository).findByEmail(userEmail);
+//
+//        doReturn(Optional.of(1))
+//            .when(playlistTrackRepository).findMaxPlaySequenceByPlaylistId(playlist.getId());
+//
+//        doReturn(playlist)
+//            .when(playlistRepository).save(any(Playlist.class));
+//
+//        doReturn(Optional.of(Track.builder().build()))
+//            .when(trackRepository).findById(anyLong());
+//
+//        doReturn(PlaylistTrack.builder().build())
+//            .when(playlistTrackRepository).save(any(PlaylistTrack.class));
+//
+//        //when
+//        MessageResponse messageResponse = playlistTrackService.savePlaylistTrackList(requestDto,
+//            accessToken);
+//
+//        //then
+//        assertThat(messageResponse.getCode()).isEqualTo(REQUEST_SUCCESS.getCode());
+//        assertThat(messageResponse.getMessage()).isEqualTo(REQUEST_SUCCESS.getMessage());
+//
+//    }
 
-        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
-            .playlistTitle("플리 타이틀")
-            .alarmStartTime(LocalTime.now())
-            .listSequence(1)
-            .trackIdList(List.of(1L, 2L, 3L))
-            .build();
-
-        Playlist playlist = requestDto.toPlaylistEntity();
-
-        doReturn(userEmail)
-            .when(jwtTokenProvider).getUserPk(accessToken);
-
-        doReturn(Optional.of(User.builder().email(userEmail).build()))
-            .when(userRepository).findByEmail(userEmail);
-
-        doReturn(Optional.of(1))
-            .when(playlistTrackRepository).findMaxPlaySequenceByPlaylistId(playlist.getId());
-
-        doReturn(playlist)
-            .when(playlistRepository).save(any(Playlist.class));
-
-        doReturn(Optional.of(Track.builder().build()))
-            .when(trackRepository).findById(anyLong());
-
-        doReturn(PlaylistTrack.builder().build())
-            .when(playlistTrackRepository).save(any(PlaylistTrack.class));
-
-        //when
-        MessageResponse messageResponse = playlistTrackService.savePlaylistTrackList(requestDto,
-            accessToken);
-
-        //then
-        assertThat(messageResponse.getCode()).isEqualTo(REQUEST_SUCCESS.getCode());
-        assertThat(messageResponse.getMessage()).isEqualTo(REQUEST_SUCCESS.getMessage());
-
-    }
-
-    @Test
-    void 트랙이_존재하지않으면_EntityNotFoundException() throws AccountException {
-        //given
-        final String accessToken = "accessToken";
-        final String userEmail = "test@email.com";
-
-        User user = User.builder().email(userEmail).build();
-
-        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
-            .playlistTitle("플리 타이틀")
-            .alarmStartTime(LocalTime.now())
-            .listSequence(1)
-            .trackIdList(List.of(1L, 2L, 3L))
-            .build();
-
-        Playlist playlist = requestDto.toPlaylistEntity();
-
-        doReturn(userEmail)
-            .when(jwtTokenProvider).getUserPk(accessToken);
-        doReturn(Optional.of(user))
-            .when(userRepository).findByEmail(userEmail);
-
-        //when
-        //then
-        assertThatThrownBy(
-            () -> playlistTrackService.savePlaylistTrackList(requestDto, accessToken))
-            .isInstanceOf(EntityNotFoundException.class);
-    }
+//    @Test
+//    void 트랙이_존재하지않으면_EntityNotFoundException() throws AccountException {
+//        //given
+//        final String accessToken = "accessToken";
+//        final String userEmail = "test@email.com";
+//
+//        User user = User.builder().email(userEmail).build();
+//
+//        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+//            .playlistTitle("플리 타이틀")
+//            .alarmStartTime(LocalTime.now())
+//            .listSequence(1)
+//            .trackIdList(List.of(1L, 2L, 3L))
+//            .build();
+//
+//        Playlist playlist = requestDto.toPlaylistEntity();
+//
+//        doReturn(userEmail)
+//            .when(jwtTokenProvider).getUserPk(accessToken);
+//        doReturn(Optional.of(user))
+//            .when(userRepository).findByEmail(userEmail);
+//
+//        //when
+//        //then
+//        assertThatThrownBy(
+//            () -> playlistTrackService.savePlaylistTrackList(requestDto, accessToken))
+//            .isInstanceOf(EntityNotFoundException.class);
+//    }
 
     @Test
     void 사용자가_존재하지않으면_UsernameNotFoundException() {
@@ -177,7 +182,7 @@ class PlaylistTrackServiceTest {
             .playlistTitle("플리 타이틀")
             .alarmStartTime(LocalTime.now())
             .listSequence(1)
-            .trackIdList(List.of(1L, 2L, 3L))
+            .trackList(List.of(TrackRequest.builder().build()))
             .build();
 
         //when
@@ -186,4 +191,196 @@ class PlaylistTrackServiceTest {
             () -> playlistTrackService.savePlaylistTrackList(requestDto, accessToken))
             .isInstanceOf(UsernameNotFoundException.class);
     }
+
+    @Test
+    void 트랙_저장_성공_플레이리스트ID리스트가_비어있고_track이_존재하지않으면_트랙_신규_저장_및_플레이리스트_신규_저장() throws AccountException {
+        //given
+        final String accessToken = "accessToken";
+        final String userEmail = "test@email.com";
+        final User user = User.builder().email(userEmail).build();
+
+        TrackRequest trackRequest = TrackRequest.builder()
+                .trackTitle("test track")
+                .albumImageUrl("url/track")
+                .spotifyTrackId(spotifyTrackId)
+                .spotifyTrackHref("href string")
+                .trackArtistList(List.of("test artist"))
+                .build();
+
+        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+                .playlistTitle("플리 타이틀")
+                .alarmStartTime(LocalTime.now())
+                .listSequence(1)
+                .trackList(List.of(trackRequest))
+                .build();
+
+        doReturn(userEmail)
+                .when(jwtTokenProvider).getUserPk(accessToken);
+        doReturn(Optional.of(user))
+                .when(userRepository).findByEmail(userEmail);
+
+        //when
+        final MessageResponse result = playlistTrackService.savePlaylistTrackList(requestDto, accessToken);
+
+        //then
+        assertThat(result.getCode()).isEqualTo(REQUEST_SUCCESS.getCode());
+        assertThat(result.getMessage()).isEqualTo(REQUEST_SUCCESS.getMessage());
+
+    }
+
+    @Test
+    void 트랙_저장_성공_플레이리스트ID리스트가_비어있고_track이_존재하면_플레이리스트_신규_저장() throws AccountException {
+        //given
+        final String accessToken = "accessToken";
+        final String userEmail = "test@email.com";
+        final User user = User.builder().email(userEmail).build();
+
+        TrackRequest trackRequest = TrackRequest.builder()
+                .trackTitle("test track")
+                .albumImageUrl("url/track")
+                .spotifyTrackId(spotifyTrackId)
+                .spotifyTrackHref("href string")
+                .trackArtistList(List.of("test artist"))
+                .build();
+        Track track = trackRequest.toTrackEntity();
+
+        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+                .playlistTitle("플리 타이틀")
+                .alarmStartTime(LocalTime.now())
+                .listSequence(1)
+                .trackList(List.of(trackRequest))
+                .build();
+
+        doReturn(userEmail)
+                .when(jwtTokenProvider).getUserPk(accessToken);
+        doReturn(Optional.of(user))
+                .when(userRepository).findByEmail(userEmail);
+        doReturn(Optional.of(track))
+                .when(trackRepository).findBySpotifyTrackId(trackRequest.getSpotifyTrackId());
+
+        //when
+        final MessageResponse result = playlistTrackService.savePlaylistTrackList(requestDto, accessToken);
+
+        //then
+        assertThat(result.getCode()).isEqualTo(REQUEST_SUCCESS.getCode());
+        assertThat(result.getMessage()).isEqualTo(REQUEST_SUCCESS.getMessage());
+    }
+
+    @Test
+    void 트랙_저장_성공_플레이리스트ID리스트가_비어있지않고_track이_존재하지않으면_트랙_신규_저장_및_플레이리스트_트랙_추가() throws AccountException {
+        //given
+        final String accessToken = "accessToken";
+        final String userEmail = "test@email.com";
+        final User user = User.builder().email(userEmail).build();
+
+        TrackRequest trackRequest = TrackRequest.builder()
+                .trackTitle("test track")
+                .albumImageUrl("url/track")
+                .spotifyTrackId(spotifyTrackId)
+                .spotifyTrackHref("href string")
+                .trackArtistList(List.of("test artist"))
+                .build();
+
+        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+                .playlistIdList(List.of(1L,2L,3L))
+                .playlistTitle("플리 타이틀")
+                .alarmStartTime(LocalTime.now())
+                .listSequence(1)
+                .trackList(List.of(trackRequest))
+                .build();
+        Playlist playlist = requestDto.toPlaylistEntity();
+
+        doReturn(userEmail)
+                .when(jwtTokenProvider).getUserPk(accessToken);
+        doReturn(Optional.of(user))
+                .when(userRepository).findByEmail(userEmail);
+        doReturn(Optional.of(playlist))
+                .when(playlistRepository).findById(anyLong());
+
+        //when
+        final MessageResponse result = playlistTrackService.savePlaylistTrackList(requestDto, accessToken);
+
+        //then
+        assertThat(result.getCode()).isEqualTo(REQUEST_SUCCESS.getCode());
+        assertThat(result.getMessage()).isEqualTo(REQUEST_SUCCESS.getMessage());
+
+    }
+
+    @Test
+    void 트랙_저장_성공_플레이리스트ID리스트가_비어있지않고_track이_존재하면_플레이리스트_트랙_추가() throws AccountException {
+        //given
+        final String accessToken = "accessToken";
+        final String userEmail = "test@email.com";
+        final User user = User.builder().email(userEmail).build();
+
+        TrackRequest trackRequest = TrackRequest.builder()
+                .trackTitle("test track")
+                .albumImageUrl("url/track")
+                .spotifyTrackId(spotifyTrackId)
+                .spotifyTrackHref("href string")
+                .trackArtistList(List.of("test artist"))
+                .build();
+        Track track = trackRequest.toTrackEntity();
+
+        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+                .playlistIdList(List.of(1L,2L,3L))
+                .playlistTitle("플리 타이틀")
+                .alarmStartTime(LocalTime.now())
+                .listSequence(1)
+                .trackList(List.of(trackRequest))
+                .build();
+        Playlist playlist = requestDto.toPlaylistEntity();
+
+        doReturn(userEmail)
+                .when(jwtTokenProvider).getUserPk(accessToken);
+        doReturn(Optional.of(user))
+                .when(userRepository).findByEmail(userEmail);
+        doReturn(Optional.of(track))
+                .when(trackRepository).findBySpotifyTrackId(trackRequest.getSpotifyTrackId());
+        doReturn(Optional.of(playlist))
+                .when(playlistRepository).findById(anyLong());
+
+        //when
+        final MessageResponse result = playlistTrackService.savePlaylistTrackList(requestDto, accessToken);
+
+        //then
+        assertThat(result.getCode()).isEqualTo(REQUEST_SUCCESS.getCode());
+        assertThat(result.getMessage()).isEqualTo(REQUEST_SUCCESS.getMessage());
+
+    }
+
+    @Test
+    void 트랙_저장_실패_playlistIdList_중_존재하지않는_플레이리스트_포함됨() throws PlaylistException {
+        final String accessToken = "accessToken";
+        final String userEmail = "test@email.com";
+        final User user = User.builder().email(userEmail).build();
+
+        TrackRequest trackRequest = TrackRequest.builder()
+                .trackTitle("test track")
+                .albumImageUrl("url/track")
+                .spotifyTrackId(spotifyTrackId)
+                .spotifyTrackHref("href string")
+                .trackArtistList(List.of("test artist"))
+                .build();
+
+        PlaylistTrackSaveRequestDto requestDto = PlaylistTrackSaveRequestDto.builder()
+                .playlistIdList(List.of(1L,2L,3L))
+                .playlistTitle("플리 타이틀")
+                .alarmStartTime(LocalTime.now())
+                .listSequence(1)
+                .trackList(List.of(trackRequest))
+                .build();
+
+        doReturn(userEmail)
+                .when(jwtTokenProvider).getUserPk(accessToken);
+        doReturn(Optional.of(user))
+                .when(userRepository).findByEmail(userEmail);
+
+        // when
+        final Throwable thrown = catchThrowable(() -> playlistTrackService.savePlaylistTrackList(requestDto, accessToken));
+
+        // then
+        assertThat(thrown.getMessage()).isEqualTo("플레이리스트가 존재하지 않습니다.");
+    }
+
 }

--- a/src/test/java/com/team/comma/spotify/track/repository/TrackRepositoryTest.java
+++ b/src/test/java/com/team/comma/spotify/track/repository/TrackRepositoryTest.java
@@ -21,22 +21,21 @@ public class TrackRepositoryTest {
     @Autowired
     private TrackRepository trackRepository;
 
-    private final String title = "test track";
-
+    private String spotifyTrackId = "input ISRC of track";
     @Test
-    public void 곡_저장() {
+    void 곡_저장() {
         // given
 
         // when
-        final Track result = trackRepository.save(getTrack(title));
+        final Track result = trackRepository.save(buildTrack("test track"));
 
         // then
         assertThat(result).isNotNull();
-        assertThat(result.getTrackTitle()).isEqualTo(title);
+        assertThat(result.getTrackTitle()).isEqualTo("test track");
     }
 
     @Test
-    public void 곡_조회_실패_곡정보없음() {
+    void 곡_조회_실패_곡정보없음() {
         // given
 
         // when
@@ -47,20 +46,46 @@ public class TrackRepositoryTest {
     }
 
     @Test
-    public void 곡_조회_성공() {
+    void 곡_조회_성공() {
         // given
-        final Track track = trackRepository.save(getTrack("track test"));
+        final Track track = trackRepository.save(buildTrack("test track"));
 
         // when
         final Optional<Track> result = trackRepository.findById(track.getId());
 
         // then
         assertThat(result).isNotEmpty();
+        assertThat(result).isEqualTo(Optional.of(track));
     }
 
-    private Track getTrack(String title) {
+    @Test
+    void spotify_track_id로_곡_조회_성공(){
+        // given
+        final Track track = trackRepository.save(buildTrack("test track"));
+
+        // when
+        final Optional<Track> result = trackRepository.findBySpotifyTrackId(spotifyTrackId);
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).isEqualTo(Optional.of(track));
+    }
+
+    @Test
+    void spotify_track_id로_곡_조회_실패_곡정보없음(){
+        // given
+
+        // when
+        final Optional<Track> result = trackRepository.findBySpotifyTrackId(spotifyTrackId);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    private Track buildTrack(String title) {
         return Track.builder()
             .trackTitle(title)
+            .spotifyTrackId(spotifyTrackId)
             .build();
     }
 


### PR DESCRIPTION
<h2>Jira Issue 번호</h2>

81

<h2>작업 내용</h2>

- 플레이리스트 트랙 추가 기능 구현
- playlistTrackSaveRequestDto에 playlistIdList와 trackRequestList에 트랙 정보를 추가로 받아옴
- playlistIdList가 비어있으면 신규 생성 그렇지 않으면 기존 플레이리스트에 트랙 추가
- 신규 생성 혹은 기존 플리에 트랙 추가 모두 트랙이 존재하는 지 먼저 확인 후 없으면 트랙 저장 후 플리에 추가

<h2>기타</h2>

- 깃허브 잔디가 안 심어져서 이것저것 해보다가 커밋 기록이 지저분해서 브랜치를 새로 만듬
- 지금도 지저분한 기록이 좀 있는데 양해 바랍니다...

<h2>Check-List</h2>

- [x] PR 제목이 convention 에 맞는지 체크
- [x] PR Label 설정
- [x] Code Review 요청
- [x] Jira 리뷰 요청 상태로 변경