### PR TITLE
feat: 쿠키 자동 삭제 로직 구현

### DIFF
--- a/src/main/java/com/team/comma/util/auth/support/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/team/comma/util/auth/support/OAuth2AuthenticationSuccessHandler.java
@@ -43,8 +43,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         Token token = jwtTokenProvider.createAccessToken(user.getEmail(), UserRole.USER);
 
-        response.addHeader("Set-Cookie" , createResponseAccessToken(token.getAccessToken()).toString());
-        response.addHeader("Set-Cookie" , createResponseRefreshToken(token.getRefreshToken()).toString());
+        response.addHeader("Set-Cookie" , createResponseAccessToken(token.getAccessToken() , 30 * 60 * 1000L).toString());
+        response.addHeader("Set-Cookie" , createResponseRefreshToken(token.getRefreshToken() , 14 * 24 * 60 * 60 * 1000L).toString());
 
         httpSession.removeAttribute("user");
 

--- a/src/main/java/com/team/comma/util/exception/handler/ExceptionHandlerFilter.java
+++ b/src/main/java/com/team/comma/util/exception/handler/ExceptionHandlerFilter.java
@@ -2,6 +2,7 @@ package com.team.comma.util.exception.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team.comma.common.dto.MessageResponse;
+import com.team.comma.util.jwt.exception.RequireRefreshToken;
 import com.team.comma.util.jwt.exception.TokenForgeryException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -9,12 +10,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 import static com.team.comma.common.constant.ResponseCodeEnum.AUTHORIZATION_ERROR;
+import static com.team.comma.util.jwt.support.CreationCookie.deleteAccessTokenCookie;
+import static com.team.comma.util.jwt.support.CreationCookie.deleteCookie;
 
 @Component
 public class ExceptionHandlerFilter extends OncePerRequestFilter {
@@ -27,6 +31,16 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
         } catch (TokenForgeryException e) {
+            deleteCookie(response);
+
+            setErrorResponse(response, AUTHORIZATION_ERROR.getCode() , e.getMessage());
+        } catch (UsernameNotFoundException e) {
+            deleteCookie(response);
+
+            setErrorResponse(response, AUTHORIZATION_ERROR.getCode() , e.getMessage());
+        } catch (RequireRefreshToken e) {
+            deleteAccessTokenCookie(response);
+
             setErrorResponse(response, AUTHORIZATION_ERROR.getCode() , e.getMessage());
         }
     }

--- a/src/main/java/com/team/comma/util/jwt/exception/RequireRefreshToken.java
+++ b/src/main/java/com/team/comma/util/jwt/exception/RequireRefreshToken.java
@@ -1,0 +1,7 @@
+package com.team.comma.util.jwt.exception;
+
+public class RequireRefreshToken extends RuntimeException {
+    public RequireRefreshToken(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/team/comma/util/jwt/service/CustomUserDetailService.java
+++ b/src/main/java/com/team/comma/util/jwt/service/CustomUserDetailService.java
@@ -17,7 +17,7 @@ public class CustomUserDetailService implements UserDetailsService {
 
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return loginRepository.findByEmail(email)
-            .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+            .orElseThrow(() -> new UsernameNotFoundException("토큰이 변조됐거나 사용자를 찾을 수 없습니다."));
     }
 
 }

--- a/src/main/java/com/team/comma/util/jwt/support/CreationCookie.java
+++ b/src/main/java/com/team/comma/util/jwt/support/CreationCookie.java
@@ -15,7 +15,7 @@ public class CreationCookie {
                 .httpOnly(true)
                 //.secure(true)
                 .path("/")
-                .domain("localhost")
+                .domain("comma-project.p-e.kr")
                 //.sameSite(Cookie.SameSite.NONE.name())
                 .maxAge(age)
                 .build();
@@ -26,7 +26,7 @@ public class CreationCookie {
                 .httpOnly(true)
                 //.secure(true)
                 .path("/")
-                .domain("localhost")
+                .domain("comma-project.p-e.kr")
                 //.sameSite(Cookie.SameSite.NONE.name())
                 .maxAge(age)
                 .build();

--- a/src/main/java/com/team/comma/util/jwt/support/CreationCookie.java
+++ b/src/main/java/com/team/comma/util/jwt/support/CreationCookie.java
@@ -10,31 +10,44 @@ import org.springframework.http.ResponseCookie;
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class CreationCookie {
 
-    public static ResponseCookie createResponseAccessToken(String cookieName) {
+    public static ResponseCookie createResponseAccessToken(String cookieName , long age) {
         return ResponseCookie.from("accessToken", cookieName)
                 .httpOnly(true)
                 //.secure(true)
                 .path("/")
-                .domain("comma-project.p-e.kr")
+                .domain("localhost")
                 //.sameSite(Cookie.SameSite.NONE.name())
-                .maxAge(30 * 60 * 1000L)
+                .maxAge(age)
                 .build();
     }
 
-    public static ResponseCookie createResponseRefreshToken(String cookieName) {
+    public static ResponseCookie createResponseRefreshToken(String cookieName , long age) {
         return ResponseCookie.from("refreshToken", cookieName)
                 .httpOnly(true)
                 //.secure(true)
                 .path("/")
-                .domain("comma-project.p-e.kr")
+                .domain("localhost")
                 //.sameSite(Cookie.SameSite.NONE.name())
-                .maxAge(14 * 24 * 60 * 60 * 1000L)
+                .maxAge(age)
                 .build();
     }
 
     public static void setCookieFromJwt(HttpServletResponse response , Token token) {
-        response.addHeader("Set-Cookie" , createResponseAccessToken(token.getAccessToken()).toString());
-        response.addHeader("Set-Cookie" , createResponseRefreshToken(token.getRefreshToken()).toString());
+        response.addHeader("Set-Cookie" , createResponseAccessToken(token.getAccessToken() , 30 * 60 * 1000L).toString());
+        response.addHeader("Set-Cookie" , createResponseRefreshToken(token.getRefreshToken() , 14 * 24 * 60 * 60 * 1000L).toString());
+    }
+
+    public static void deleteCookie(HttpServletResponse response) {
+        deleteAccessTokenCookie(response);
+        deleteRefreshTokenCookie(response);
+    }
+
+    public static void deleteAccessTokenCookie(HttpServletResponse response) {
+        response.addHeader("Set-Cookie" , createResponseAccessToken("accessToken" , 0).toString());
+    }
+
+    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
+        response.addHeader("Set-Cookie" , createResponseRefreshToken("refreshToken" , 0).toString());
     }
 
 }

--- a/src/main/java/com/team/comma/util/jwt/support/JwtTokenProvider.java
+++ b/src/main/java/com/team/comma/util/jwt/support/JwtTokenProvider.java
@@ -11,6 +11,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -23,13 +24,13 @@ import java.util.Base64;
 import java.util.Date;
 
 @Component
-@RequiredArgsConstructor
 public class JwtTokenProvider {
 
     private String secretKey = "secretKey";
     private String refreshKey = "refreshKey";
 
-    private final UserDetailsService userDetailsService;
+    @Autowired
+    private UserDetailsService userDetailsService;
 
     private long tokenValidTime = 30 * 60 * 1000L;
     private long refreshTokenValidTime = 14 * 24 * 60 * 60 * 1000L;

--- a/src/main/java/com/team/comma/util/jwt/support/JwtTokenProvider.java
+++ b/src/main/java/com/team/comma/util/jwt/support/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.team.comma.util.jwt.support;
 
+import com.team.comma.util.jwt.exception.RequireRefreshToken;
 import com.team.comma.util.jwt.exception.TokenForgeryException;
 import com.team.comma.user.constant.UserRole;
 import com.team.comma.util.security.domain.RefreshToken;
@@ -28,85 +29,71 @@ public class JwtTokenProvider {
     private String secretKey = "secretKey";
     private String refreshKey = "refreshKey";
 
-    @Autowired
-    private UserDetailsService userDetailsService;
+    private final UserDetailsService userDetailsService;
 
-
-    // Access 토큰 유효시간 30분;
     private long tokenValidTime = 30 * 60 * 1000L;
-    // Refresh 토큰 유효시간 14주 14 * 24 * 60 * 60 *
     private long refreshTokenValidTime = 14 * 24 * 60 * 60 * 1000L;
 
-    // 객체 초기화, secretKey를 Base64로 인코딩한다.
     @PostConstruct
     protected void init() {
         secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
         refreshKey = Base64.getEncoder().encodeToString(refreshKey.getBytes());
     }
 
-    // JWT 토큰 생성
     public Token createAccessToken(String userPk, UserRole role) {
         Claims claims = Jwts.claims()
-            .setSubject(userPk); // JWT payload 에 저장되는 정보단위, 보통 여기서 user를 식별하는 값을 넣는다.
-        claims.put("roles", role); // 정보는 key / value 쌍으로 저장된다.
+            .setSubject(userPk);
+        claims.put("roles", role);
         Date now = new Date();
 
-        String accessToken = Jwts.builder().setClaims(claims) // 정보 저장
-            .setIssuedAt(now) // 토큰 발행 시간 정보
-            .setExpiration(new Date(now.getTime() + tokenValidTime)) // set Expire Time
-            .signWith(SignatureAlgorithm.HS256, secretKey) // 사용할 암호화 알고리즘과
-            // signature 에 들어갈 secret값 세팅
+        String accessToken = Jwts.builder().setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + tokenValidTime))
+            .signWith(SignatureAlgorithm.HS256, secretKey)
             .compact();
 
         // RefreshToken 발급
-        String refreshToken = Jwts.builder().setClaims(claims) // 정보 저장
-            .setIssuedAt(now) // 토큰 발행 시간 정보
-            .setExpiration(new Date(now.getTime() + refreshTokenValidTime)) // set Expire Time
-            .signWith(SignatureAlgorithm.HS256, refreshKey) // 사용할 암호화 알고리즘과
-            // signature 에 들어갈 secret값 세팅
+        String refreshToken = Jwts.builder().setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + refreshTokenValidTime))
+            .signWith(SignatureAlgorithm.HS256, refreshKey)
             .compact();
 
         return Token.builder().accessToken(accessToken).refreshToken(refreshToken).key(userPk)
             .build();
     }
 
-    // refreshToken 유효성 검사
     public String validateRefreshToken(RefreshToken refreshTokenObj) {
-        // refresh 객체에서 refreshToken 추출
         String refreshToken = refreshTokenObj.getToken();
         try {
             // 검증
             Jws<Claims> claims = Jwts.parser().setSigningKey(refreshKey)
                 .parseClaimsJws(refreshToken);
 
-            // refresh 토큰의 만료시간이 지나지 않았을 경우, 새로운 access 토큰을 생성합니다.
             if (!claims.getBody().getExpiration().before(new Date())) {
                 return recreationAccessToken(claims.getBody().get("sub").toString(),
                     claims.getBody().get("roles"));
             }
         } catch (Exception e) {
-            return null; // refresh 토큰이 만료되었을 경우, 로그인이 필요합니다.
+            return null;
         }
         return null;
     }
 
-    // Access토큰 재 생성
     public String recreationAccessToken(String userEmail, Object roles) {
-        Claims claims = Jwts.claims().setSubject(userEmail); // JWT payload 에 저장되는 정보단위
-        claims.put("roles", roles); // 정보는 key / value 쌍으로 저장된다.
+        Claims claims = Jwts.claims().setSubject(userEmail);
+        claims.put("roles", roles);
         Date now = new Date();
-        // Access Token
-        String accessToken = Jwts.builder().setClaims(claims) // 정보 저장
-            .setIssuedAt(now) // 토큰 발행 시간 정보
-            .setExpiration(new Date(now.getTime() + tokenValidTime)) // set Expire Time
-            .signWith(SignatureAlgorithm.HS256, secretKey) // 사용할 암호화 알고리즘과
-            // signature 에 들어갈 secret값 세팅
+
+        String accessToken = Jwts.builder().setClaims(claims)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + tokenValidTime))
+            .signWith(SignatureAlgorithm.HS256, secretKey)
             .compact();
 
         return accessToken;
     }
 
-    // JWT 토큰에서 인증 정보 조회
     public Authentication getAuthentication(String token) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserPk(token));
         if (userDetails == null) {
@@ -116,23 +103,16 @@ public class JwtTokenProvider {
             userDetails.getAuthorities());
     }
 
-    // 토큰에서 회원 정보 추출
     public String getUserPk(String token) {
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
     }
 
-    // Request의 Header에서 token 값을 가져옵니다. "Authorization" : "TOKEN값'
-    public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("Authorization");
-    }
-
-    // 토큰의 유효성 + 만료일자 확인
     public boolean validateToken(String jwtToken) {
         try {
             Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
             return !claims.getBody().getExpiration().before(new Date());
         } catch (Exception e) {
-            throw new TokenForgeryException("알 수 없는 토큰이거나 , 변조되었습니다.");
+            throw new RequireRefreshToken("AccessToken이 만료되었습니다.");
         }
     }
 }

--- a/src/main/java/com/team/comma/util/jwt/support/JwtTokenProvider.java
+++ b/src/main/java/com/team/comma/util/jwt/support/JwtTokenProvider.java
@@ -29,7 +29,6 @@ public class JwtTokenProvider {
     private String secretKey = "secretKey";
     private String refreshKey = "refreshKey";
 
-    @Autowired
     private UserDetailsService userDetailsService;
 
     private long tokenValidTime = 30 * 60 * 1000L;

--- a/src/main/java/com/team/comma/util/security/controller/SecurityController.java
+++ b/src/main/java/com/team/comma/util/security/controller/SecurityController.java
@@ -3,6 +3,7 @@ package com.team.comma.util.security.controller;
 import com.team.comma.common.constant.ResponseCodeEnum;
 import com.team.comma.common.dto.MessageResponse;
 import com.team.comma.util.jwt.service.JwtService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,18 +18,18 @@ import static com.team.comma.common.constant.ResponseCodeEnum.AUTHORIZATION_ERRO
 @RequiredArgsConstructor
 public class SecurityController {
 
-    final private JwtService jwtService;
+    private final JwtService jwtService;
 
     @GetMapping(value = "/authentication/denied")
     public ResponseEntity<MessageResponse> informAuthenticationDenied(
-        @CookieValue(name = "refreshToken", required = false) String authorization) {
+            @CookieValue(name = "refreshToken", required = false) String authorization , HttpServletResponse response) {
         if (authorization == null) {
             MessageResponse message = MessageResponse.of(AUTHENTICATION_ERROR, "인증되지 않은 사용자입니다.");
 
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(message);
         }
 
-        return jwtService.validateRefreshToken(authorization);
+        return jwtService.validateRefreshToken(response , authorization);
     }
 
     @GetMapping(value = "/authorization/denied")
@@ -36,12 +37,6 @@ public class SecurityController {
         MessageResponse message = MessageResponse.of(AUTHORIZATION_ERROR , "인가되지 않은 사용자입니다.");
 
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(message);
-    }
-
-
-    @GetMapping("/security")
-    public String getSecurity() {
-        return "Security";
     }
 
     @GetMapping(value = "/logout/message")

--- a/src/test/java/com/team/comma/user/service/UserServiceTest.java
+++ b/src/test/java/com/team/comma/user/service/UserServiceTest.java
@@ -70,7 +70,6 @@ class UserServiceTest {
 
     private final String userEmail = "email@naver.com";
     private final String userPassword = "password";
-    private final String userName = "userName";
 
     private MockHttpServletRequest request; // request mock
 

--- a/src/test/java/com/team/comma/util/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/team/comma/util/jwt/service/JwtServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -59,12 +60,13 @@ class JwtServiceTest {
     void createAccessToken() {
         // given
         RefreshToken refreshToken = getRefreshToken();
+        MockHttpServletResponse response = new MockHttpServletResponse();
         Optional<RefreshToken> tokens = Optional.of(refreshToken);
         doReturn(tokens).when(refreshTokenRepository).findByToken(refreshToken.getToken());
         doReturn("Token").when(jwtTokenProvider).validateRefreshToken(any(RefreshToken.class));
 
         // when
-        ResponseEntity result = jwtService.validateRefreshToken(refreshToken.getToken());
+        ResponseEntity result = jwtService.validateRefreshToken(response , refreshToken.getToken());
 
         // then
         assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -76,13 +78,14 @@ class JwtServiceTest {
     void expireToken() {
         // given
         RefreshToken refreshToken = getRefreshToken();
+        MockHttpServletResponse response = new MockHttpServletResponse();
         Optional<RefreshToken> tokens = Optional.of(refreshToken);
         doReturn(tokens).when(refreshTokenRepository).findByToken(refreshToken.getToken());
         doReturn(null).when(jwtTokenProvider).validateRefreshToken(any(RefreshToken.class));
 
         // when
         Throwable thrown = catchThrowable(
-            () -> jwtService.validateRefreshToken(refreshToken.getToken()));
+            () -> jwtService.validateRefreshToken(response , refreshToken.getToken()));
 
         // then
         assertThat(thrown).isInstanceOf(TokenExpirationException.class)
@@ -95,12 +98,13 @@ class JwtServiceTest {
     void falsifyToken() {
         // given
         RefreshToken refreshToken = getRefreshToken();
+        MockHttpServletResponse response = new MockHttpServletResponse();
         doThrow(NoSuchElementException.class).when(refreshTokenRepository)
             .findByToken(refreshToken.getToken());
 
         // when
         Throwable thrown = catchThrowable(
-            () -> jwtService.validateRefreshToken(refreshToken.getToken()));
+            () -> jwtService.validateRefreshToken(response , refreshToken.getToken()));
 
         // then
         assertThat(thrown).isInstanceOf(TokenForgeryException.class)

--- a/src/test/java/com/team/comma/util/security/controller/SecurityControllerTest.java
+++ b/src/test/java/com/team/comma/util/security/controller/SecurityControllerTest.java
@@ -32,6 +32,8 @@ import java.nio.charset.StandardCharsets;
 import static com.team.comma.common.constant.ResponseCodeEnum.*;
 import static org.apache.http.cookie.SM.SET_COOKIE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.cookies.CookieDocumentation.*;
@@ -103,7 +105,7 @@ public class SecurityControllerTest {
         final String api = "/authentication/denied";
         MockHttpServletResponse response = new MockHttpServletResponse();
         doThrow(new TokenForgeryException("변조되거나, 알 수 없는 RefreshToken 입니다."))
-                .when(jwtService).validateRefreshToken(response , "token");
+                .when(jwtService).validateRefreshToken(any() , eq("token"));
 
         // when
         final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
@@ -139,10 +141,9 @@ public class SecurityControllerTest {
         // given
         final String api = "/authentication/denied";
         MockHttpServletResponse response = new MockHttpServletResponse();
-        ResponseCookie responseCookieData = ResponseCookie.from("accessToken", "newAccessToken")
-                .build();
+        ResponseCookie responseCookieData = ResponseCookie.from("accessToken", "newAccessToken").build();
         doReturn(ResponseEntity.status(HttpStatus.OK).header(SET_COOKIE, responseCookieData.toString())
-                        .body(MessageResponse.of(ACCESS_TOKEN_CREATE))).when(jwtService).validateRefreshToken(response , "token");
+                        .body(MessageResponse.of(ACCESS_TOKEN_CREATE))).when(jwtService).validateRefreshToken(any() , eq("token"));
 
         // when
         final ResultActions resultActions = mockMvc.perform(

--- a/src/test/java/com/team/comma/util/security/controller/SecurityControllerTest.java
+++ b/src/test/java/com/team/comma/util/security/controller/SecurityControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -100,8 +101,9 @@ public class SecurityControllerTest {
     public void createAccessTokenFail_falsifiedToken() throws Exception {
         // given
         final String api = "/authentication/denied";
+        MockHttpServletResponse response = new MockHttpServletResponse();
         doThrow(new TokenForgeryException("변조되거나, 알 수 없는 RefreshToken 입니다."))
-                .when(jwtService).validateRefreshToken("token");
+                .when(jwtService).validateRefreshToken(response , "token");
 
         // when
         final ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
@@ -136,10 +138,11 @@ public class SecurityControllerTest {
     public void createNewAccessToken() throws Exception {
         // given
         final String api = "/authentication/denied";
+        MockHttpServletResponse response = new MockHttpServletResponse();
         ResponseCookie responseCookieData = ResponseCookie.from("accessToken", "newAccessToken")
                 .build();
         doReturn(ResponseEntity.status(HttpStatus.OK).header(SET_COOKIE, responseCookieData.toString())
-                        .body(MessageResponse.of(ACCESS_TOKEN_CREATE))).when(jwtService).validateRefreshToken("token");
+                        .body(MessageResponse.of(ACCESS_TOKEN_CREATE))).when(jwtService).validateRefreshToken(response , "token");
 
         // when
         final ResultActions resultActions = mockMvc.perform(


### PR DESCRIPTION
1. AccessToken이 조작 & 만료되었을 때
{
    "code": -4,
    "message": "AccessToken이 만료되었습니다.",
    "data": null
}
메세지와 함께 AccessToken 삭제

이후 다음과 같이 요청 -> /authentication/denied
{
    "code": 7,
    "message": "AccessToken이 재발급되었습니다.",
    "data": null
}
자동으로 AccessToken 발급

RefreshToken 변조 -> 다음 메세지와 함꼐 RefreshToken 삭제
{
    "code": -4,
    "message": "변조되거나, 알 수 없는 RefreshToken 입니다.",
    "data": null
}

인증이 필요한 API ->
{
    "code": -4,
    "message": "인증되지 않은 사용자입니다.",
    "data": "인증되지 않은 사용자입니다."
}